### PR TITLE
Fix "Warning: sort() expects parameter 1 to be array, null given" error

### DIFF
--- a/stanford_jumpstart_vpsa.module
+++ b/stanford_jumpstart_vpsa.module
@@ -30,11 +30,10 @@ function stanford_jumpstart_vpsa_wysiwyg_editor_settings_alter(&$settings, $cont
       }
     }
 
-  }
-
-  if (array_key_exists('stylesSet', $settings)) {
-    // Keys need to be in order for some reason.
-    sort($settings['stylesSet']);
+    if (array_key_exists('stylesSet', $settings)) {
+      // Keys need to be in order for some reason.
+      sort($settings['stylesSet']);
+    }
   }
 }
 

--- a/stanford_jumpstart_vpsa.module
+++ b/stanford_jumpstart_vpsa.module
@@ -30,10 +30,8 @@ function stanford_jumpstart_vpsa_wysiwyg_editor_settings_alter(&$settings, $cont
       }
     }
 
-    if (array_key_exists('stylesSet', $settings)) {
-      // Keys need to be in order for some reason.
-      sort($settings['stylesSet']);
-    }
+    // Keys need to be in order for some reason.
+    sort($settings['stylesSet']);
   }
 }
 

--- a/stanford_jumpstart_vpsa.module
+++ b/stanford_jumpstart_vpsa.module
@@ -31,9 +31,10 @@ function stanford_jumpstart_vpsa_wysiwyg_editor_settings_alter(&$settings, $cont
     }
 
   }
-
-  // Keys need to be in order for some reason.
-  sort($settings['stylesSet']);
+  if (array_key_exists('stylesSet',$settings)) {
+    // Keys need to be in order for some reason.
+    sort($settings['stylesSet']);
+  }
 }
 
 

--- a/stanford_jumpstart_vpsa.module
+++ b/stanford_jumpstart_vpsa.module
@@ -31,7 +31,8 @@ function stanford_jumpstart_vpsa_wysiwyg_editor_settings_alter(&$settings, $cont
     }
 
   }
-  if (array_key_exists('stylesSet',$settings)) {
+
+  if (array_key_exists('stylesSet', $settings)) {
     // Keys need to be in order for some reason.
     sort($settings['stylesSet']);
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes an error: ` Warning: sort() expects parameter 1 to be array, null given in stanford_jumpstart_vpsa_wysiwyg_editor_settings_alter() (line 36 of stanford_jumpstart_vpsa.module.`

# Needed By (Date)
- Not sure. March 15th?

# Urgency
- Not super-urgent. Fixes a PHP Warning

# Steps to Test

1. Clone `lbre-production` to local
2. Turn on error reporting
3. Go to `block/bgm-home-news--announcements-blo/edit`
4. See error message
5. Check out this branch
6. Go to `block/bgm-home-news--announcements-blo/edit`
7. Don't see error message

# Affected Projects or Products
- JSVPSA sites and LBRE sites

# Other Notes
Not sure if this should be fixed like this, or just put the `sort($settings['stylesSet']);` inside the `if ($context['profile']->format == "content_editor_text_format")` block. It's showing up on Full HTML pages.