### PR TITLE
SITES-1119: Remove dependency on webauth

### DIFF
--- a/modules/stanford_jumpstart_vpsa_layouts/stanford_jumpstart_vpsa_layouts.context.inc
+++ b/modules/stanford_jumpstart_vpsa_layouts/stanford_jumpstart_vpsa_layouts.context.inc
@@ -460,12 +460,6 @@ function stanford_jumpstart_vpsa_layouts_context_default_contexts() {
   $context->reactions = array(
     'block' => array(
       'blocks' => array(
-        'webauth-webauth_login_block' => array(
-          'module' => 'webauth',
-          'delta' => 'webauth_login_block',
-          'region' => 'global_header',
-          'weight' => '-10',
-        ),
         'stanford_jsvpsa_layouts-1' => array(
           'module' => 'menu_block',
           'delta' => 'stanford_jsvpsa_layouts-1',

--- a/modules/stanford_jumpstart_vpsa_layouts/stanford_jumpstart_vpsa_layouts.info
+++ b/modules/stanford_jumpstart_vpsa_layouts/stanford_jumpstart_vpsa_layouts.info
@@ -15,7 +15,6 @@ dependencies[] = stanford_jumpstart
 dependencies[] = stanford_news
 dependencies[] = stanford_page
 dependencies[] = views
-dependencies[] = webauth
 features[context][] = vpsa_all_pages_but_homepage
 features[context][] = vpsa_events_related
 features[context][] = vpsa_homepage_dickinson


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the dependency on webauth

# Needed By (Date)
- This is needed before we can migrate JSVPSA sites

# Criticality
- How critical is this PR on a 1-10 scale? 4/10
- Affects all of JSVPSA

# Steps to Test

1. Check out this branch
2. Install a JSVPSA site
3. Ensure that the layouts look correct

# Affected Projects or Products
- JSVPSA
- Sites 2.0

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/SITES-1119

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)